### PR TITLE
fix memory leak #1145

### DIFF
--- a/src/Microsoft.OData.Client/ODataAnnotatableExtensions.cs
+++ b/src/Microsoft.OData.Client/ODataAnnotatableExtensions.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //---------------------------------------------------------------------
 
-using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
 using System.Diagnostics;
 
 namespace Microsoft.OData.Client
@@ -30,12 +30,12 @@ namespace Microsoft.OData.Client
 
         private static class InternalDictionary<T> where T : class
         {
-            private static readonly ConcurrentDictionary<ODataAnnotatable, T> Dictionary =
-                new ConcurrentDictionary<ODataAnnotatable, T>();
+            private static readonly ConditionalWeakTable<ODataAnnotatable, T> Dictionary =
+                new ConditionalWeakTable<ODataAnnotatable, T>();
 
             public static void SetAnnotation(ODataAnnotatable annotatable, T annotation)
             {
-                Dictionary[annotatable] = annotation;
+                Dictionary.Add(annotatable,annotation); 
             }
 
             public static T GetAnnotation(ODataAnnotatable annotatable)


### PR DESCRIPTION
the memory leak occurs because the Annotatable object can never be GC'd once an annotation is attached.

There is a change in semantics here, if SetAnnotation is called twice, the second will exception, rather than updating.
This was previously a condition which would cause an error anyway, as it would orphan the previously set annotation inside CreateLink()

At the moment the only codepath to SetAnnotation is 
Microsoft.OData.Client.Materialization.MaterializerNavigationLink.CreateLink(...) 
create link is only called by FeedAndEntryMaterializerAdapter, which has an existence guard, so this should never trigger the double-insert.

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #xxx.*

### Description

*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
